### PR TITLE
Fix comments creation by making authenticated request

### DIFF
--- a/src/main/scala/ensime/autoresponder/IssueFetching.scala
+++ b/src/main/scala/ensime/autoresponder/IssueFetching.scala
@@ -34,9 +34,6 @@ trait IssueFetching {
 
   private val dateTimeFormat = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss'Z")
 
-  private lazy val authHeaders =
-    List(Authorization(GenericHttpCredentials("token", config.credentials.accessToken)))
-
   private val parallelism = 4
 
   private def issuesUrl(since: DateTime = DateTime.now) = {
@@ -54,7 +51,7 @@ trait IssueFetching {
       .map { unit =>
         val url = issuesUrl()
         logger.debug("About to fetch issues: " + url)
-        HttpRequest(uri = url, headers = authHeaders) -> unit
+        HttpRequest(uri = url) -> unit
       }
       .via(pool[Unit])
       .mapAsync(parallelism)(parseIssuesResponse)

--- a/src/main/scala/ensime/autoresponder/MainApp.scala
+++ b/src/main/scala/ensime/autoresponder/MainApp.scala
@@ -16,7 +16,8 @@ object MainApp extends App with StrictLogging {
 
   implicit val actorSystem = ActorSystem("ensime-responder")
   implicit val materializer = ActorMaterializer(
-    ActorMaterializerSettings(actorSystem) withSupervisionStrategy supervisor)
+    ActorMaterializerSettings(actorSystem) withSupervisionStrategy supervisor
+  )
   implicit val executionContext = actorSystem.dispatcher
 
   val flows = new Flows {


### PR DESCRIPTION
That was the problem with the comments: the request wasn't authenticated. It doesn't seem to cause any rate-limiting issues now and it seems that the limit is 5000 request an hour anyway, so this should be OK for now. 

By the way, there must be a better way to log stuffs in akka streams, I'll see if I can find it; using `map` doesn't look good. 
